### PR TITLE
feat!: add `Dimensions` object

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,16 @@ use Zenstruck\Image;
 $image = Image::wrap('some/local.jpg'); // create from local file
 $image = Image::from($resource); // create from resource/stream (in a temp file)
 
-// general metadata
-$image->height(); // int
-$image->width(); // int
-$image->aspectRatio(); // float
-$image->pixels(); // int
-$image->isSquare(); // bool
-$image->isLandscape(); // bool
-$image->isPortrait(); // bool
+// dimensional information
+$image->dimensions()->height(); // int
+$image->dimensions()->width(); // int
+$image->dimensions()->aspectRatio(); // float
+$image->dimensions()->pixels(); // int
+$image->dimensions()->isSquare(); // bool
+$image->dimensions()->isLandscape(); // bool
+$image->dimensions()->isPortrait(); // bool
+
+// other metadata
 $image->mimeType(); // string (ie "image/jpeg")
 $image->guessExtension(); // string - the extension if available or guess from mime-type
 $image->iptc(); // array - IPTC data (if the image supports)

--- a/src/Image.php
+++ b/src/Image.php
@@ -11,7 +11,7 @@
 
 namespace Zenstruck;
 
-use Zenstruck\Image\CalculatedProperties;
+use Zenstruck\Image\Dimensions;
 use Zenstruck\Image\TransformerRegistry;
 
 /**
@@ -19,8 +19,6 @@ use Zenstruck\Image\TransformerRegistry;
  */
 final class Image extends \SplFileInfo
 {
-    use CalculatedProperties;
-
     private const MIME_EXTENSION_MAP = [
         'image/jpeg' => 'jpg',
         'image/gif' => 'gif',
@@ -35,6 +33,8 @@ final class Image extends \SplFileInfo
 
     /** @var mixed[] */
     private array $imageMetadata;
+
+    private Dimensions $dimensions;
 
     /** @var array<string,string> */
     private array $iptc;
@@ -87,14 +87,9 @@ final class Image extends \SplFileInfo
         return self::transformerRegistry()->get($class)->object($this);
     }
 
-    public function height(): int
+    public function dimensions(): Dimensions
     {
-        return $this->imageMetadata()[1];
-    }
-
-    public function width(): int
-    {
-        return $this->imageMetadata()[0];
+        return $this->dimensions ??= new Dimensions(fn() => $this->imageMetadata()); // @phpstan-ignore-line
     }
 
     public function mimeType(): string
@@ -195,7 +190,7 @@ final class Image extends \SplFileInfo
     {
         \clearstatcache(filename: $this);
 
-        unset($this->imageMetadata, $this->exif, $this->iptc);
+        unset($this->imageMetadata, $this->exif, $this->iptc, $this->dimensions);
 
         return $this;
     }

--- a/src/Image/Dimensions.php
+++ b/src/Image/Dimensions.php
@@ -14,8 +14,25 @@ namespace Zenstruck\Image;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-trait CalculatedProperties
+final class Dimensions
 {
+    /**
+     * @param array{0:int,1:int}|callable():array{0:int,1:int} $values
+     */
+    public function __construct(private $values)
+    {
+    }
+
+    public function width(): int
+    {
+        return $this->values()[0];
+    }
+
+    public function height(): int
+    {
+        return $this->values()[1];
+    }
+
     public function aspectRatio(): float
     {
         return $this->width() / $this->height();
@@ -39,5 +56,17 @@ trait CalculatedProperties
     public function isLandscape(): bool
     {
         return $this->width() > $this->height();
+    }
+
+    /**
+     * @return array{0:int,1:int}
+     */
+    private function values(): array
+    {
+        if (\is_callable($this->values)) {
+            return $this->values = ($this->values)();
+        }
+
+        return $this->values;
     }
 }

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -71,7 +71,7 @@ final class ImageTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
 
-        $image->height();
+        $image->dimensions()->height();
     }
 
     /**
@@ -96,37 +96,37 @@ final class ImageTest extends TestCase
         $image = Image::from(new \SplFileInfo(__DIR__.'/Fixture/files/symfony.jpg'));
 
         $this->assertSame('image/jpeg', $image->mimeType());
-        $this->assertSame(678, $image->height());
-        $this->assertSame(563, $image->width());
+        $this->assertSame(678, $image->dimensions()->height());
+        $this->assertSame(563, $image->dimensions()->width());
         $this->assertSame([], $image->iptc());
         $this->assertSame(678, $image->exif()['computed.Height']);
 
         \file_put_contents($image, \file_get_contents(__DIR__.'/Fixture/files/metadata.jpg'));
 
         $this->assertSame('image/jpeg', $image->mimeType());
-        $this->assertSame(678, $image->height());
-        $this->assertSame(563, $image->width());
+        $this->assertSame(678, $image->dimensions()->height());
+        $this->assertSame(563, $image->dimensions()->width());
         $this->assertSame([], $image->iptc());
         $this->assertSame(678, $image->exif()['computed.Height']);
 
         $this->assertSame($image, $image->refresh());
 
         $this->assertSame('image/jpeg', $image->mimeType());
-        $this->assertSame(16, $image->height());
-        $this->assertSame(16, $image->width());
+        $this->assertSame(16, $image->dimensions()->height());
+        $this->assertSame(16, $image->dimensions()->width());
         $this->assertSame('Lorem Ipsum', $image->iptc()['DocumentTitle']);
         $this->assertSame(16, $image->exif()['computed.Height']);
     }
 
     private function metadataAssertions(Image $image, int $height, int $width, string $mime, string $extension): void
     {
-        $this->assertSame($height, $image->height());
-        $this->assertSame($width, $image->width());
-        $this->assertSame($width * $height, $image->pixels());
-        $this->assertSame($width / $height, $image->aspectRatio());
-        $this->assertSame($height === $width, $image->isSquare());
-        $this->assertSame($height < $width, $image->isLandscape());
-        $this->assertSame($height > $width, $image->isPortrait());
+        $this->assertSame($height, $image->dimensions()->height());
+        $this->assertSame($width, $image->dimensions()->width());
+        $this->assertSame($width * $height, $image->dimensions()->pixels());
+        $this->assertSame($width / $height, $image->dimensions()->aspectRatio());
+        $this->assertSame($height === $width, $image->dimensions()->isSquare());
+        $this->assertSame($height < $width, $image->dimensions()->isLandscape());
+        $this->assertSame($height > $width, $image->dimensions()->isPortrait());
         $this->assertSame($mime, $image->mimeType());
         $this->assertSame($extension, $image->guessExtension());
     }

--- a/tests/Transformer/FilterObjectTransformerTest.php
+++ b/tests/Transformer/FilterObjectTransformerTest.php
@@ -29,15 +29,15 @@ abstract class FilterObjectTransformerTest extends TransformerTest
 
         $resized = $image->transform($this->filterCallback());
 
-        $this->assertSame(100, $resized->width());
-        $this->assertSame(120, $resized->height());
+        $this->assertSame(100, $resized->dimensions()->width());
+        $this->assertSame(120, $resized->dimensions()->height());
         $this->assertSame('jpg', $resized->getExtension());
         $this->assertSame('/tmp', \dirname($resized));
 
         $resized = $image->transform($this->filterObject(), ['format' => 'png']);
 
-        $this->assertSame(100, $resized->width());
-        $this->assertSame(120, $resized->height());
+        $this->assertSame(100, $resized->dimensions()->width());
+        $this->assertSame(120, $resized->dimensions()->height());
         $this->assertSame('png', $resized->getExtension());
         $this->assertSame('/tmp', \dirname($resized));
     }
@@ -53,8 +53,8 @@ abstract class FilterObjectTransformerTest extends TransformerTest
         $resized = $image->transform($this->filterObject(), ['output' => $output]);
 
         $this->assertSame((string) $output, (string) $resized);
-        $this->assertSame(100, $resized->width());
-        $this->assertSame(120, $resized->height());
+        $this->assertSame(100, $resized->dimensions()->width());
+        $this->assertSame(120, $resized->dimensions()->height());
         $this->assertSame('image/jpeg', $resized->mimeType());
     }
 
@@ -65,17 +65,17 @@ abstract class FilterObjectTransformerTest extends TransformerTest
     {
         $image = Image::from(new \SplFileInfo(__DIR__.'/../Fixture/files/symfony.jpg'));
 
-        $this->assertSame(678, $image->height());
-        $this->assertSame(563, $image->width());
+        $this->assertSame(678, $image->dimensions()->height());
+        $this->assertSame(563, $image->dimensions()->width());
 
         $resized = $image->transformInPlace($this->filterObject());
 
         $this->assertSame($image, $resized);
         $this->assertSame((string) $image, (string) $resized);
-        $this->assertSame(100, $resized->width());
-        $this->assertSame(120, $resized->height());
-        $this->assertSame(100, $image->width());
-        $this->assertSame(120, $image->height());
+        $this->assertSame(100, $resized->dimensions()->width());
+        $this->assertSame(120, $resized->dimensions()->height());
+        $this->assertSame(100, $image->dimensions()->width());
+        $this->assertSame(120, $image->dimensions()->height());
     }
 
     abstract protected function filterObject(): object;

--- a/tests/TransformerTest.php
+++ b/tests/TransformerTest.php
@@ -29,15 +29,15 @@ abstract class TransformerTest extends TestCase
 
         $resized = $image->transform($this->filterCallback());
 
-        $this->assertSame(100, $resized->width());
-        $this->assertSame(120, $resized->height());
+        $this->assertSame(100, $resized->dimensions()->width());
+        $this->assertSame(120, $resized->dimensions()->height());
         $this->assertSame('jpg', $resized->getExtension());
         $this->assertSame('/tmp', \dirname($resized));
 
         $resized = $image->transform($this->filterCallback(), ['format' => 'png']);
 
-        $this->assertSame(100, $resized->width());
-        $this->assertSame(120, $resized->height());
+        $this->assertSame(100, $resized->dimensions()->width());
+        $this->assertSame(120, $resized->dimensions()->height());
         $this->assertSame('png', $resized->getExtension());
         $this->assertSame('/tmp', \dirname($resized));
     }
@@ -53,8 +53,8 @@ abstract class TransformerTest extends TestCase
         $resized = $image->transform($this->filterCallback(), ['output' => $output]);
 
         $this->assertSame((string) $output, (string) $resized);
-        $this->assertSame(100, $resized->width());
-        $this->assertSame(120, $resized->height());
+        $this->assertSame(100, $resized->dimensions()->width());
+        $this->assertSame(120, $resized->dimensions()->height());
         $this->assertSame('image/jpeg', $resized->mimeType());
     }
 
@@ -65,17 +65,17 @@ abstract class TransformerTest extends TestCase
     {
         $image = Image::from(new \SplFileInfo(__DIR__.'/Fixture/files/symfony.jpg'));
 
-        $this->assertSame(678, $image->height());
-        $this->assertSame(563, $image->width());
+        $this->assertSame(678, $image->dimensions()->height());
+        $this->assertSame(563, $image->dimensions()->width());
 
         $resized = $image->transformInPlace($this->filterCallback());
 
         $this->assertSame($image, $resized);
         $this->assertSame((string) $image, (string) $resized);
-        $this->assertSame(100, $resized->width());
-        $this->assertSame(120, $resized->height());
-        $this->assertSame(100, $image->width());
-        $this->assertSame(120, $image->height());
+        $this->assertSame(100, $resized->dimensions()->width());
+        $this->assertSame(120, $resized->dimensions()->height());
+        $this->assertSame(100, $image->dimensions()->width());
+        $this->assertSame(120, $image->dimensions()->height());
     }
 
     /**
@@ -87,15 +87,15 @@ abstract class TransformerTest extends TestCase
 
         $resized = $image->transform($this->filterInvokable());
 
-        $this->assertSame(100, $resized->width());
-        $this->assertSame(120, $resized->height());
+        $this->assertSame(100, $resized->dimensions()->width());
+        $this->assertSame(120, $resized->dimensions()->height());
         $this->assertSame('jpg', $resized->getExtension());
         $this->assertSame('/tmp', \dirname($resized));
 
         $resized = $image->transform($this->filterCallback(), ['format' => 'png']);
 
-        $this->assertSame(100, $resized->width());
-        $this->assertSame(120, $resized->height());
+        $this->assertSame(100, $resized->dimensions()->width());
+        $this->assertSame(120, $resized->dimensions()->height());
         $this->assertSame('png', $resized->getExtension());
         $this->assertSame('/tmp', \dirname($resized));
     }
@@ -111,8 +111,8 @@ abstract class TransformerTest extends TestCase
         $resized = $image->transform($this->filterInvokable(), ['output' => $output]);
 
         $this->assertSame((string) $output, (string) $resized);
-        $this->assertSame(100, $resized->width());
-        $this->assertSame(120, $resized->height());
+        $this->assertSame(100, $resized->dimensions()->width());
+        $this->assertSame(120, $resized->dimensions()->height());
         $this->assertSame('image/jpeg', $resized->mimeType());
     }
 
@@ -123,17 +123,17 @@ abstract class TransformerTest extends TestCase
     {
         $image = Image::from(new \SplFileInfo(__DIR__.'/Fixture/files/symfony.jpg'));
 
-        $this->assertSame(678, $image->height());
-        $this->assertSame(563, $image->width());
+        $this->assertSame(678, $image->dimensions()->height());
+        $this->assertSame(563, $image->dimensions()->width());
 
         $resized = $image->transformInPlace($this->filterInvokable());
 
         $this->assertSame($image, $resized);
         $this->assertSame((string) $image, (string) $resized);
-        $this->assertSame(100, $resized->width());
-        $this->assertSame(120, $resized->height());
-        $this->assertSame(100, $image->width());
-        $this->assertSame(120, $image->height());
+        $this->assertSame(100, $resized->dimensions()->width());
+        $this->assertSame(120, $resized->dimensions()->height());
+        $this->assertSame(100, $image->dimensions()->width());
+        $this->assertSame(120, $image->dimensions()->height());
     }
 
     /**


### PR DESCRIPTION
BC BREAKS:
- Remove `CalculatedProperties` trait and methods on `Image`
- Remove `Image::width()` and `Image::height()`